### PR TITLE
Feature/pictureModal

### DIFF
--- a/client/src/components/Product.jsx
+++ b/client/src/components/Product.jsx
@@ -94,7 +94,7 @@ class Product extends React.Component {
         <GlobalStyles />
         
         <PicturesSection>
-          <PicturesView pictureURLs={this.state.image_urls} />
+          <PicturesView pictureURLs={this.state.image_urls} name={this.state.name} />
         </PicturesSection>
 
         <ContentSection>

--- a/client/src/components/picture/PictureDisplay.jsx
+++ b/client/src/components/picture/PictureDisplay.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import Caption from '../styledComponents/Caption.jsx';
 import PrePicture from '../styledComponents/PrePicture.jsx';
 import TileAndZoom from './TileAndZoom.jsx';
+import PictureModal from './PictureModal.jsx';
 
 class PictureDisplay extends React.Component {
   constructor(props) {
@@ -10,9 +11,12 @@ class PictureDisplay extends React.Component {
     this.state = {
       hovered: false,
       tileCenterCoords: [0, 0],
+      clicked: false,
     };
     this.onMouseOver = this.onMouseOver.bind(this);
     this.onMouseLeaveImg = this.onMouseLeaveImg.bind(this);
+    this.displayPictureModal = this.displayPictureModal.bind(this);
+    this.removePictureModal = this.removePictureModal.bind(this);
   }
 
   onMouseOver(e) {
@@ -34,6 +38,20 @@ class PictureDisplay extends React.Component {
     });
   }
 
+  displayPictureModal() {
+    this.setState({
+      hovered: false,
+      clicked: true,
+    });
+  }
+
+  removePictureModal() {
+    document.body.style.overflow = 'visible';
+    this.setState({
+      clicked: false,
+    });
+  }
+
   render() {
     const Picture = styled(PrePicture)`
       margin-top: calc(-1 * ${ this.props.numPictures } * 55px);
@@ -41,10 +59,17 @@ class PictureDisplay extends React.Component {
 
     return  (
       <Picture>
-        <img onMouseEnter={ this.onMouseOver } onMouseOver={ this.onMouseOver } onMouseLeave={ this.onMouseLeaveImg } src={ this.props.pictureURL } ></img>
+        <img onMouseEnter={ this.onMouseOver } onMouseOver={ this.onMouseOver } onMouseLeave={ this.onMouseLeaveImg }
+          src={ this.props.pictureURL } ></img>
         { this.state.hovered && this.state.tileCenterCoords ?
           <TileAndZoom xCoord={ this.state.tileCenterCoords[0] } yCoord={ this.state.tileCenterCoords[1] }
-            changeProductDisplayHoveredState={ this.onMouseLeaveImg } pictureURL={ this.props.pictureURL } />
+            changeProductDisplayHoveredState={ this.onMouseLeaveImg } pictureURL={ this.props.pictureURL }
+            displayPictureModal={ this.displayPictureModal } />
+          : ''
+        }
+        { this.state.clicked ?
+          <PictureModal idSelected={ this.props.idSelected } onXClick={ this.removePictureModal } name={ this.props.name }
+            pictureURLs={ this.props.pictureURLs } />
           : ''
         }
         <Caption>{ this.state.hovered ? 'Click image to open expanded view' : 'Roll over image to zoom in' }</Caption>

--- a/client/src/components/picture/PictureModal.jsx
+++ b/client/src/components/picture/PictureModal.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { PictureModalBox, PictureModalBackground, PictureModalHeader, X,
+  PictureModalIcon, PictureModalDescription, PictureModalSelectedIcon, imgDisplayed, imgIconStyle } from '../styledComponents/PictureModalBox.jsx';
+import GrayLine from '../styledComponents/GrayLine.jsx';
+
+class PictureModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      idSelected: this.props.idSelected,
+    };
+    this.onIconClick = this.onIconClick.bind(this);
+  }
+
+  onIconClick(e) {
+    this.setState({
+      idSelected: Number(e.target.id),
+    });
+  }
+
+  render() {
+    document.body.style.overflow = 'hidden';
+
+    return (
+      <div>
+        <PictureModalBackground onClick={ this.props.onXClick }></PictureModalBackground>
+
+        <PictureModalBox>
+          <PictureModalHeader>
+            IMAGES <X onClick={ this.props.onXClick }>&times;</X>
+          </PictureModalHeader>
+          <GrayLine></GrayLine>
+          
+          <img style={ imgDisplayed } id={ this.state.idSelected } src={ this.props.pictureURLs[this.state.idSelected] }></img>
+
+          <PictureModalDescription>
+            <p>{ this.props.name }</p>
+            { this.props.pictureURLs.map((url, id) => {
+              return id === this.state.idSelected ? 
+                <PictureModalSelectedIcon style={ imgIconStyle } src={ url } id={ id } key={ id } onClick={ this.onIconClick } />
+              :
+                <PictureModalIcon style={ imgIconStyle } src={ url } id={ id } key={ id } onClick={ this.onIconClick } />
+             })
+            }
+          </PictureModalDescription>
+        </PictureModalBox>
+      </div>
+    );
+  }
+}
+
+export default PictureModal;

--- a/client/src/components/picture/PicturesView.jsx
+++ b/client/src/components/picture/PicturesView.jsx
@@ -22,10 +22,15 @@ class PicturesView extends React.Component {
     return (
       <div>
         <PictureList 
-          pictureURLs={this.props.pictureURLs} 
-          onHover={this.onIconHoverHandler}
-          idSelected={this.state.idSelected} />
-        <PictureDisplay pictureURL={this.props.pictureURLs[this.state.idSelected]} numPictures={this.props.pictureURLs.length} />
+          pictureURLs={ this.props.pictureURLs }
+          onHover={ this.onIconHoverHandler }
+          idSelected={ this.state.idSelected } />
+        <PictureDisplay
+          pictureURLs={ this.props.pictureURLs }
+          pictureURL={ this.props.pictureURLs[this.state.idSelected] }
+          numPictures={ this.props.pictureURLs.length }
+          idSelected={ this.state.idSelected }
+          name={ this.props.name } />
       </div>
     );
   }

--- a/client/src/components/picture/TileAndZoom.jsx
+++ b/client/src/components/picture/TileAndZoom.jsx
@@ -15,6 +15,7 @@ class TileAndZoom extends React.Component {
     };
     this.onMouseMove = this.onMouseMove.bind(this);
     this.onMouseOut = this.onMouseOut.bind(this);
+    this.onTileClick = this.onTileClick.bind(this);
   }
 
   onMouseMove(e) {
@@ -41,6 +42,10 @@ class TileAndZoom extends React.Component {
       hovered: false,
     })
     this.props.changeProductDisplayHoveredState();
+  }
+
+  onTileClick() {
+    this.props.displayPictureModal();
   }
 
   toPixel(x) {
@@ -76,8 +81,8 @@ class TileAndZoom extends React.Component {
 
     return (this.state.hovered ? 
       <TileAndZoomStyle>
-        <img src={ tileURL } style={ tileStyle } 
-          onMouseMove={ this.onMouseMove } onMouseOut={ this.onMouseOut }></img>
+        <img src={ tileURL } style={ tileStyle } onMouseMove={ this.onMouseMove }
+          onMouseOut={ this.onMouseOut } onClick={ this.onTileClick }></img>
         <div style={ zoomStyle } onMouseOver={ this.onMouseOut } ></div>
       </TileAndZoomStyle>
       : ''

--- a/client/src/components/styledComponents/PictureModalBox.jsx
+++ b/client/src/components/styledComponents/PictureModalBox.jsx
@@ -1,0 +1,88 @@
+import styled from 'styled-components';
+
+const PictureModalBackground = styled.div`
+  background-color: rgba(0, 0, 0, 0.7);
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  z-index: 3;
+  overflow: hidden;
+`;
+
+const PictureModalBox = styled.div`
+  position: fixed;
+  top: 11%;
+  bottom: 11%;
+  left: 3%;
+  right: 3%;
+  z-index: 5;
+  align-content: center;
+  vertical-align: center;
+  border-radius: 5px;
+  padding: 25px;
+  background-color: white;
+`;
+
+const PictureModalHeader = styled.span`
+  position: relative;
+  color: rgb(0, 47, 54);
+  font-size: 15px;
+  padding: 0px 20px 15px 20px;
+`;
+
+const X = styled.span`
+  outline-color: orange;
+  float: right;
+  font-size: 25px;
+  margin-top: -15px;
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+const PictureModalDescription = styled.span`
+  color: rgb(83, 83, 83);
+  width: 30%;
+  p {
+    font-size: 16px;
+  }
+`;
+
+const PictureModalIcon = styled.img`
+  border: 2px solid rgb(210, 210, 210);
+  :hover {
+    border: 2px solid rgb(0, 47, 54);
+  }
+`;
+
+const PictureModalSelectedIcon = styled.img`
+  border: 2px solid orange;
+`;
+
+const imgDisplayed = {
+  float: 'left',
+  padding: '20px',
+  paddingLeft: '10%',
+  width: '75%',
+  maxHeight: 400,
+  height: 'auto',
+};
+
+const imgIconStyle = {
+  height: 50,
+  width: 50,
+};
+
+export {
+  PictureModalBox,
+  PictureModalBackground,
+  PictureModalHeader,
+  X,
+  PictureModalDescription,
+  PictureModalIcon,
+  PictureModalSelectedIcon,
+  imgDisplayed,
+  imgIconStyle,
+};


### PR DESCRIPTION
In this PR the bare minimum features of an Amazon product's picture modal were implemented.  When a user clicks on the displayed product image, a modal is displayed. In it, the clicked image is the main display. The name of the product and the rest of the images in icons are displayed in order and to the right. When one of these image icons is clicked, it's rendered as the main (displayed) image in the modal.

Changes in files:
**Product.jsx** and **PicturesView.jsx**
- Pass the product's `name` from the `Product` component —> `PicturesView` —> `PictureDisplay` —> `PictureModal`, where it's needed to be rendered.

**PictureDisplay.jsx**
- Add two functions: `displayPictureModal`, `removePictureModal`. They both change `PictureDisplay`'s `clicked` state from `true` to `false` (or viceversa). This state property renders the `PictureModal` conditionally (if it's `true`, the `PictureModal` component is displayed; if `false`, `PictureModal` is not rendered).
- Add the conditional render of `PictureModal` to the `render()` function.

**TileAndZoom.jsx**
- Add `onTileClick` function so it can change `PictureDisplay`'s `clicked` property. This makes `PictureModal` render.

**PictureModal.jsx** and **PictureModalBox.jsx**
- Implement the `PictureModal` component with styling imported from PictureModalBox.jsx's styled components.




